### PR TITLE
Update for zig 0.13.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,4 @@ dist
 
 ## Zig wasm build output
 build/
+.zig-cache

--- a/core/build.zig
+++ b/core/build.zig
@@ -25,7 +25,7 @@ pub fn build(b: *std.Build) void {
         .name = "spreadsheet",
         // In this case the main source file is merely a path, however, in more
         // complicated build scripts, this could be a generated file.
-        .root_source_file = .{ .path = "src/main.zig" },
+        .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
     });
@@ -59,25 +59,25 @@ pub fn build(b: *std.Build) void {
     run_step.dependOn(&run_cmd.step);
 
     const run_lexer_tests = addUnitTest(b, .{
-        .root_source_file = .{ .path = "src/lexer.zig" },
+        .root_source_file = b.path("src/lexer.zig"),
         .target = target,
         .optimize = optimize,
     });
 
     const run_parser_tests = addUnitTest(b, .{
-        .root_source_file = .{ .path = "src/parser.zig" },
+        .root_source_file = b.path("src/parser.zig"),
         .target = target,
         .optimize = optimize,
     });
 
     const run_engine_tests = addUnitTest(b, .{
-        .root_source_file = .{ .path = "src/engine.zig" },
+        .root_source_file = b.path("src/engine.zig"),
         .target = target,
         .optimize = optimize,
     });
 
     const run_map_tests = addUnitTest(b, .{
-        .root_source_file = .{ .path = "src/map.zig" },
+        .root_source_file = b.path("src/map.zig"),
         .target = target,
         .optimize = optimize,
     });

--- a/core/src/engine.zig
+++ b/core/src/engine.zig
@@ -213,7 +213,7 @@ const BuiltInFunc = enum {
     product,
 };
 
-const func_lookup = std.ComptimeStringMap(BuiltInFunc, .{
+const func_lookup = std.StaticStringMap(BuiltInFunc).initComptime(.{
     .{ "__LOAD__", .__load__ },
     .{ "SUM", .sum },
     .{ "AVG", .avg },


### PR DESCRIPTION
- Ignore .zig-out directory
- Use b.path helper in build.zig
- Replace std.ComptimeStringMap with std.StaticStringMap