### PR TITLE
CSS tweaks

### DIFF
--- a/src/web/shell.html
+++ b/src/web/shell.html
@@ -32,6 +32,18 @@
             -ms-interpolation-mode: nearest-neighbor;
         }
 
+        table,
+        th,
+        td {
+            border: 1px solid white;
+            border-collapse: collapse;
+        }
+
+        th,
+        td {
+            padding: 5px;
+        }
+
         .side-panel {
             position: fixed;
             top: 20px;


### PR DESCRIPTION
- Fixes issue where scrolling the markdown panel would scroll the Copy button along with it
- Adds borders to the table

<img width="507" height="896" alt="Screenshot 2025-07-20 at 6 11 57 PM" src="https://github.com/user-attachments/assets/19af8619-9554-4403-ad91-6bf8f6c1017c" />
