### PR TITLE
Start side panel collapsed on mobile

### DIFF
--- a/src/web/shell.html
+++ b/src/web/shell.html
@@ -88,6 +88,13 @@
             transition: background-color 0.2s;
         }
 
+        @media (max-width: 768px) {
+            .toggle-button {
+                top: auto;
+                bottom: 20px;
+            }
+        }
+
         .toggle-button:hover {
             background-color: rgba(21, 50, 71, 0.9);
         }


### PR DESCRIPTION
So that the side panel isn't blocking the grid on load.