### PR TITLE
Smoother touch pan

### DIFF
--- a/src/root.zig
+++ b/src/root.zig
@@ -146,6 +146,8 @@ export fn frame() void {
             // Stop momentum when speed is too low
             state.touch_state.velocity = Vec2{ 0, 0 };
         }
+    } else {
+        clearMomentum();
     }
 
     clear();


### PR DESCRIPTION
Smooths out the touchscreen pan by decreasing the distance threshold.

Also clears out the momentum if velocity is insufficient.