### PR TITLE
Disable newline insertion for now

### DIFF
--- a/src/ui.zig
+++ b/src/ui.zig
@@ -1010,7 +1010,8 @@ pub const UI = struct {
     }
 
     pub fn handleEnter(self: *UI, allocator: Allocator, modifiers: u32) void {
-        if (modifiers & sapp.modifier_shift != 0) {
+        const ENABLE_NEWLINE = false;
+        if (modifiers & sapp.modifier_shift != 0 and ENABLE_NEWLINE) {
             self.insertNewline(allocator);
             return;
         }


### PR DESCRIPTION
Weird behavior such as

<img width="705" height="191" alt="Screenshot 2025-09-06 at 12 51 57 AM" src="https://github.com/user-attachments/assets/e303cb73-900f-4f16-9538-6790bdd75de5" />
